### PR TITLE
WIP: rpmautospec plugin

### DIFF
--- a/mock-core-configs/etc/mock/templates/fedora-eln.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-eln.tpl
@@ -17,6 +17,8 @@ config_opts['package_manager'] = 'dnf'
 # Per https://github.com/fedora-eln/eln/issues/164 updated up to 4 times a day.
 # Docs: https://docs.fedoraproject.org/en-US/eln/deliverables/#_container_image
 config_opts['bootstrap_image'] = 'quay.io/fedoraci/fedora:eln'
+# Per https://github.com/fedora-eln/eln/issues/166
+config_opts['bootstrap_image_ready'] = True
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -29,7 +29,8 @@ from .util import set_use_nspawn, setup_operations_timeout
 PLUGIN_LIST = ['tmpfs', 'root_cache', 'yum_cache', 'mount', 'bind_mount',
                'ccache', 'selinux', 'package_state', 'chroot_scan',
                'lvm_root', 'compress_logs', 'sign', 'pm_request',
-               'hw_info', 'procenv', 'showrc', 'rpkg_preprocessor']
+               'hw_info', 'procenv', 'showrc', 'rpkg_preprocessor',
+               'rpmautospec']
 
 def nspawn_supported():
     """Detect some situations where the systemd-nspawn chroot code won't work"""
@@ -201,6 +202,14 @@ def setup_default_config_opts():
         'rpkg_preprocessor_opts': {
             'requires': ['preproc-rpmspec'],
             'cmd': '/usr/bin/preproc-rpmspec %(source_spec)s --output %(target_spec)s',
+        },
+        'rpmautospec_enable': False,
+        'rpmautospec_opts': {
+            'requires': ['rpmautospec'],
+            'cmd_base': [
+                '/usr/bin/rpmautospec',
+                'process-distgit',
+            ]
         },
     }
 

--- a/mock/py/mockbuild/plugins/rpmautospec.py
+++ b/mock/py/mockbuild/plugins/rpmautospec.py
@@ -92,10 +92,10 @@ class RpmautospecPlugin:
            self.buildroot.pkg_manager.install_as_root(*self.opts["requires"], check=True)
 
         # Get paths inside the chroot by chopping off the leading paths
-        rootdir_prefix = self.buildroot.make_chroot_path()
-        chroot_spec = host_chroot_spec.replace(rootdir_prefix, "")
-        chroot_sources = host_chroot_sources.replace(rootdir_prefix, "")
-        chroot_sources_spec = host_chroot_sources_spec.replace(rootdir_prefix, "")
+        chroot_dir = Path(self.buildroot.make_chroot_path())
+        chroot_spec = Path("/") / hosts_chroot_spec.relative_to(chroot_dir)
+        chroot_sources = Path("/") / hosts_chroot_sources.relative_to(chroot_dir)
+        chroot_sources_spec = Path("/") / hosts_chroot_sources_spec.relative_to(chroot_dir)
 
         # Call subprocess to perform the specfile rewrite
         command = self.get("cmd_base")

--- a/mock/py/mockbuild/plugins/rpmautospec.py
+++ b/mock/py/mockbuild/plugins/rpmautospec.py
@@ -9,6 +9,7 @@ from typing import Optional, Union
 
 from rpmautospec_core import specfile_uses_rpmautospec
 
+from mockbuild.exception import ConfigError
 from mockbuild.trace_decorator import getLog, traceLog
 
 requires_api_version = "1.1"
@@ -98,10 +99,13 @@ class RpmautospecPlugin:
         chroot_sources_spec = Path("/") / hosts_chroot_sources_spec.relative_to(chroot_dir)
 
         # Call subprocess to perform the specfile rewrite
-        command = self.get("cmd_base")
-        command += ["--input", chroot_sources_spec]
-        command += ["--output", chroot_spec]
-        command += ["--git-dir", chroot_sources]
+        try:
+            command = self.opts["cmd_base"]
+        except KeyError as err:
+            raise ConfigError("The 'rpmautospec_opts.cmd_base' is unset")
+
+        command += [chroot_sources_spec]  # <input-spec>
+        command += [chroot_spec]  # <output-spec>
 
         self.buildroot.doChroot(
             command,

--- a/mock/py/mockbuild/plugins/rpmautospec.py
+++ b/mock/py/mockbuild/plugins/rpmautospec.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+# vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:textwidth=0:
+# License: GPL2 or later see COPYING
+# Copyright (C) 2023 Stephen Gallagher <sgallagh@redhat.com>
+# Copyright (C) 2023 Nils Philippsen <nils@redhat.com>
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Optional, Union
+
+from rpmautospec_core import specfile_uses_rpmautospec
+
+from mockbuild.trace_decorator import getLog, traceLog
+
+requires_api_version = "1.1"
+
+
+@traceLog()
+def init(plugins, conf, buildroot):
+    RpmautospecPlugin(plugins, conf, buildroot)
+
+
+class RpmautospecPlugin:
+    """Fill in release and changelog from git history using rpmautospec"""
+
+    @traceLog()
+    def __init__(self, plugins, conf, buildroot):
+        self.buildroot = buildroot
+        self.opts = conf
+        self.log = getLog()
+        plugins.add_hook("pre_srpm_build", self.attempt_process_distgit)
+        self.log.info("rpmautospec: initialized")
+
+    @contextmanager
+    def as_root_user(self):
+        try:
+            self.buildroot.uid_manager.becomeUser(0, 0)
+            yield
+        finally:
+            self.buildroot.uid_manager.restorePrivs()
+
+    @traceLog()
+    def attempt_process_distgit(
+        self,
+        host_chroot_spec: Union[Path, str],
+        host_chroot_sources: Optional[Union[Path, str]],
+    ) -> None:
+        # Set up variables and check prerequisites.
+        if not host_chroot_sources:
+            self.log.debug("Sources not specified, skipping rpmautospec preprocessing.")
+            return
+
+        host_chroot_spec = Path(host_chroot_spec)
+        host_chroot_sources = Path(host_chroot_sources)
+        if not host_chroot_sources.is_dir():
+            self.log.debug(
+                "Sources not a directory, skipping rpmautospec preprocessing."
+            )
+            return
+
+        distgit_git_dir = host_chroot_sources / ".git"
+        if not distgit_git_dir.is_dir():
+            self.log.debug(
+                "Sources is not a git repository, skipping rpmautospec preprocessing."
+            )
+            return
+
+        host_chroot_sources_spec = host_chroot_sources / host_chroot_spec.name
+        if not host_chroot_sources_spec.is_file():
+            self.log.debug(
+                "Sources doesn’t contain spec file, skipping rpmautospec preprocessing."
+            )
+            return
+
+        with host_chroot_spec.open("rb") as spec, host_chroot_sources_spec.open(
+            "rb"
+        ) as sources_spec:
+            if spec.read() != sources_spec.read():
+                self.log.warning(
+                    "Spec file inside and outside sources are different, skipping rpmautospec"
+                    " preprocessing."
+                )
+                return
+
+        if not specfile_uses_rpmautospec(host_chroot_sources_spec):
+            self.log_debug(
+                "Spec file doesn’t use rpmautospec, skipping rpmautospec preprocessing."
+            )
+            return
+
+        # Install the `rpmautospec` command line tool into the build root.
+        if self.opts.get("requires", None):
+           self.buildroot.pkg_manager.install_as_root(*self.opts["requires"], check=True)
+
+        # Get paths inside the chroot by chopping off the leading paths
+        rootdir_prefix = self.buildroot.make_chroot_path()
+        chroot_spec = host_chroot_spec.replace(rootdir_prefix, "")
+        chroot_sources = host_chroot_sources.replace(rootdir_prefix, "")
+        chroot_sources_spec = host_chroot_sources_spec.replace(rootdir_prefix, "")
+
+        # Call subprocess to perform the specfile rewrite
+        command = self.get("cmd_base")
+        command += ["--input", chroot_sources_spec]
+        command += ["--output", chroot_spec]
+        command += ["--git-dir", chroot_sources]
+
+        self.buildroot.doChroot(
+            command,
+            shell=False,
+            cwd=chroot_sources,
+            logger=self.buildroot.build_log,
+            uid=self.buildroot.chrootuid,
+            gid=self.buildroot.chrootgid,
+            user=self.buildroot.chrootuser,
+            unshare_net=not self.config.get("rpmbuild_networking", False),
+            nspawn_args=self.config.get("nspawn_args", []),
+            printOutput=self.config.get("print_main_output", True),
+        )

--- a/mock/py/mockbuild/plugins/rpmautospec.py
+++ b/mock/py/mockbuild/plugins/rpmautospec.py
@@ -28,6 +28,10 @@ class RpmautospecPlugin:
         self.buildroot = buildroot
         self.opts = conf
         self.log = getLog()
+
+        if "cmd_base" not in self.opts:
+            raise ConfigError("The 'rpmautospec_opts.cmd_base' is unset")
+
         plugins.add_hook("pre_srpm_build", self.attempt_process_distgit)
         self.log.info("rpmautospec: initialized")
 
@@ -99,11 +103,7 @@ class RpmautospecPlugin:
         chroot_sources_spec = Path("/") / hosts_chroot_sources_spec.relative_to(chroot_dir)
 
         # Call subprocess to perform the specfile rewrite
-        try:
-            command = self.opts["cmd_base"]
-        except KeyError as err:
-            raise ConfigError("The 'rpmautospec_opts.cmd_base' is unset")
-
+        command = self.opts["cmd_base"]
         command += [chroot_sources_spec]  # <input-spec>
         command += [chroot_spec]  # <output-spec>
 

--- a/releng/release-notes-next/eln-bootstrap-image-ready.config
+++ b/releng/release-notes-next/eln-bootstrap-image-ready.config
@@ -1,0 +1,6 @@
+The default `fedora-eln-*` bootstrap image `quay.io/fedoraci/fedora:eln` [has
+been fixed](https://github.com/fedora-eln/eln/issues/166) to provide
+the `dnf builddep` command.  It means it is now "ready for bootstrap" right
+after the image download (no additional packages need to be installed inside)
+which makes the buildroot preparation
+[much faster](https://rpm-software-management.github.io/mock/Feature-container-for-bootstrap).

--- a/releng/release-notes-next/generate_buildrequires_prep.feature
+++ b/releng/release-notes-next/generate_buildrequires_prep.feature
@@ -1,0 +1,22 @@
+Only run the `%prep` section once when running `%generate_buildrequires`
+multiple times.
+Previously Mock run `%prep` repeatedly before each `%generate_buildrequires`
+round except for the last one.
+This was inconsistent and unnecessary slow/wasteful.
+
+When the original support for `%generate_buildrequires` landed into Mock,
+the intention was to only call `%prep` once.
+However when Mock added support for multiple rounds of
+`%generate_buildrequires`, `%prep` ended up only being skipped in the final
+`rpmbuild` call. This was an oversight.
+`%prep` is now only called once, as originally intended.
+
+Some RPM packages might be affected by the change, especially if a dirty
+working directory after running `%generate_buildrequires` affects the results
+of subsequent rounds of `%generate_buildrequires`.
+However, such behavior was undefined and quite buggy even previously,
+due to the lack of the `%prep` section in the final `rpmbuild` call.
+
+Packages that need to run commands before every round of
+`%generate_buildrequires` should place those commands in
+the `%generate_buildrequires` section itself rather than `%prep`.


### PR DESCRIPTION
Adds a new plugin to preprocess the RPM specfile prior to building an SRPM. This plugin will automatically install the `rpmautospec` package when necessary.

The plugin will first determine if rpmautospec macros are in use. If not, it will return control with the specfile unmodified. If the specfile requires processing, it will call out to the `/usr/bin/rpmautospec process-distgit` command with the `--input <spec>`, `--output <spec`> and `--git-dir <path>` arguments set appropriately.